### PR TITLE
Recommend compress_orderby='time ASC' for rolling up chunks

### DIFF
--- a/use-timescale/compression/manual-compression.md
+++ b/use-timescale/compression/manual-compression.md
@@ -104,7 +104,8 @@ settings to set the compress chunk time interval, and run compression operations
 to roll up the chunks while compressing.
 
 ```sql
-ALTER TABLE example SET (timescaledb.compress_chunk_time_interval = '<time_interval>');
+ALTER TABLE example SET (timescaledb.compress_chunk_time_interval = '<time_interval>',
+                         timescaledb.compress_orderby = 'time ASC');
 SELECT compress_chunk(c, if_not_compressed => true)
     FROM show_chunks(
         'example',
@@ -116,5 +117,9 @@ The time interval you choose must be a multiple of the uncompressed chunk
 interval. For example, if your uncompressed chunk interval is one week, your
 `<time_interval>` of the compressed chunk could be two weeks, or six weeks, but
 not one month.
+
+NOTE: The default setting of `compress_orderby` is `'time ASC'` which causes chunks to re-compressed
+many times during rollup which can have a steep performance penalty.
+Set `timescaledb.compress_orderby = 'time ASC'` to avoid this penalty.
 
 [add_compression_policy]: /api/:currentVersion:/compression/add_compression_policy/

--- a/use-timescale/compression/manual-compression.md
+++ b/use-timescale/compression/manual-compression.md
@@ -118,8 +118,10 @@ interval. For example, if your uncompressed chunk interval is one week, your
 `<time_interval>` of the compressed chunk could be two weeks, or six weeks, but
 not one month.
 
-NOTE: The default setting of `compress_orderby` is `'time ASC'` which causes chunks to re-compressed
+<Highlight type="note">
+The default setting of `compress_orderby` is `'time ASC'` which causes chunks to re-compressed
 many times during rollup which can have a steep performance penalty.
 Set `timescaledb.compress_orderby = 'time ASC'` to avoid this penalty.
+</Highlight>
 
 [add_compression_policy]: /api/:currentVersion:/compression/add_compression_policy/


### PR DESCRIPTION
To avoid steep performance penalty documented in GH issue: https://github.com/timescale/timescaledb/issues/5612

To be resolved by:
https://github.com/timescale/timescaledb/issues/5634

# Writing help

For information about style and word usage, see the [style guide](https://docs.timescale.com/about/latest/contribute-to-docs/)

# Review checklists

Reviewers: use this section to ensure you have checked everything before approving this PR:

## Subject matter expert (SME) review checklist

*   [ ] Is the content technically accurate?
*   [ ] Is the content complete?
*   [ ] Is the content presented in a logical order?
*   [ ] Does the content use appropriate names for features and products?
*   [ ] Does the content provide relevant links to further information?

## Documentation team review checklist

*   [ ] Is the content free from typos?
*   [ ] Does the content use plain English?
*   [ ] Does the content contain clear sections for concepts, tasks, and references?
*   [ ] Have any images been uploaded to the correct location, and are resolvable?
*   [ ] If the page index was updated, are redirects required
      and have they been implemented?
*   [ ] Have you checked the built version of this content?
